### PR TITLE
Add materials estimates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A script for checking the number of materials needed for a blueprint in Space En
     "SmallBlockLargeFlatAtmosphericThrustDShapeZZZ": 1,
     "SmallBlockSmallFlatAtmosphericThrust": 10,
     "SmallBlockArmorSlope2Tip": 6,
-    "SmallBlockSmallGenerator": 1,
+    "SmallBlockSmallGenerator": 1
   },
   "components": {
     "SteelPlate": 175,
@@ -17,7 +17,12 @@ A script for checking the number of materials needed for a blueprint in Space En
   },
   "unknown_blocks": [
     "SmallBlockLargeFlatAtmosphericThrustDShapeZZZ"
-  ]
+  ], 
+  "materials_estimate": {
+    "Iron": 8522.0, 
+    "Silicon": 57.0, 
+    "Nickel": 490.0
+  }
 }
 ```
 
@@ -45,6 +50,28 @@ The scraper script will iterate through all of these files and compile a list of
 Blocks are indexed using their TypeId first, then SubtypeId and DisplayName. If a block does not have a SubtypeId defined, then the TypeId will be used instead.
 
 If you have any custom blocks, as long as they are defined in the same format and saved in the same location, then they should just work. Full support for modded and custom blocks is coming soon.
+
+## Recipes
+
+Recipes for components are defined in an .sbc (xml format file), in the Space Engineers Data folder called `Blueprints.sbc`.
+
+```xml
+<?xml version="1.0"?>
+<Definitions xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+    <Blueprints>
+		<!-- Components -->
+        <Blueprint>
+            ...
+            <Prerequisites>
+                <Item Amount="8" TypeId="Ingot" SubtypeId="Iron" />
+            </Prerequisites>
+            <Result Amount="1" TypeId="Component" SubtypeId="Construction" />
+            ...
+        </Blueprint>
+    ...
+```
+
+Support for custom components will happen at some point in the future!
 
 ## Configuration
 
@@ -84,7 +111,7 @@ Remember you will still need to have set the paths in the config for this to wor
 
 ## To do
 
-* Display component materials estimates
+* Materials estimates for custom components and custom recipes
 * Configurable production pipeline
 * Turn this into an engine and add a lovely frontend
 

--- a/check_mats.py
+++ b/check_mats.py
@@ -1,5 +1,4 @@
 import argparse
-import json
 import os.path
 import sys
 
@@ -22,11 +21,13 @@ def check_mats(**kwargs) -> dict:
         for mod in modded_dirs:
             scraper.load_blocks(os.path.join(kwargs["config"]["mods_path"], mod, "Data", "CubeBlocks"))
 
+    scraper.load_recipes(os.path.join(kwargs["config"]["se_path"], "Data", "Blueprints.sbc"))
+
     bp_file = "blueprints/bp.sbc"
     if "file" in kwargs.keys():
         bp_file = kwargs["file"]
 
-    bpc = BluePrintChecker(scraper.all_blocks)
+    bpc = BluePrintChecker(scraper.all_blocks, scraper.all_recipes)
 
     return bpc.check_blueprint(bp_file)
 

--- a/models.py
+++ b/models.py
@@ -51,3 +51,51 @@ class Block:
                 "sub_type_id": self.sub_type_id,
                 "display_name": self.display_name,
                 "components": self.components}
+
+
+class Recipe:
+    """
+    Contains recipe details
+    """
+    def __init__(self) -> None:
+        """
+        Create a Recipe class
+
+        :return: None
+        """
+        self.materials = {}
+        self.output_type_id = None
+        self.output_quantity = None
+
+    def from_element(self, element: ElementTree) -> None:
+        """
+        Populate a recipe from an element
+
+        :param element: an XML element to create a recipe from
+        :return: None
+        """
+        this_result = element.find("Result")
+
+        if this_result is None:
+            return None
+
+        if this_result.attrib["TypeId"] is not None and this_result.attrib["TypeId"] != "Component":
+            return None
+
+        self.output_type_id = this_result.attrib["SubtypeId"]
+        self.output_quantity = float(this_result.attrib["Amount"])
+
+        for mat in element.find("Prerequisites"):
+            self.materials[mat.attrib["SubtypeId"]] = float(mat.attrib["Amount"])
+
+    def as_dict(self) -> dict:
+        """
+        Output a recipe as a dict
+
+        :return: dict
+        """
+        return {
+            "materials": self.materials,
+            "output_type_id": self.output_type_id,
+            "output_quantity": self.output_quantity
+        }

--- a/scraper.py
+++ b/scraper.py
@@ -3,7 +3,7 @@ import xml.etree.ElementTree as ElementTree
 
 from logbook import Logger
 
-from models import Block
+from models import Block, Recipe
 
 
 my_log = Logger(__name__)
@@ -20,8 +20,9 @@ class Scraper:
         Create a scraper class
         """
         self.all_blocks = {}
+        self.all_recipes = {}
 
-    def load_blocks(self, cube_blocks_path) -> None:
+    def load_blocks(self, cube_blocks_path: str) -> None:
         """
         Load the blocks from files in a content directory
 
@@ -51,3 +52,27 @@ class Scraper:
             except ElementTree.ParseError:
                 my_log.warn(f"Skipped due to ParseError: {cube_blocks_file}")
                 continue
+
+    def load_recipes(self, recipes_file: str) -> None:
+        """
+        Load the recipes from the recipes blueprint file
+
+        :return: None
+        """
+        if not os.path.isfile(recipes_file):
+            my_log.warn(f"recipes_file does not exist = {recipes_file}")
+            return None
+
+        try:
+            tree = ElementTree.parse(recipes_file)
+            for element in tree.getroot().iter("Blueprint"):
+                recipe = Recipe()
+                recipe.from_element(element)
+
+                if recipe.output_type_id is None:
+                    continue
+
+                self.all_recipes[recipe.output_type_id] = recipe.as_dict()
+
+        except ElementTree.ParseError:
+            my_log.warn(f"Skipped due to ParseError: {recipes_file}")

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 import xml.etree.ElementTree as ElementTree
 
-from models import Block
+from models import Block, Recipe
 
 
 class TestBlock:
@@ -90,4 +90,109 @@ class TestBlock:
             "sub_type_id": sub_type_id,
             "display_name": display_name,
             "components": components
+        }
+
+
+class TestRecipe:
+    """
+    A test recipe class for Recipe class tests
+    """
+    def test_new_recipe(self):
+        """
+        Make a new empty recipe
+        """
+        recipe = Recipe()
+
+        assert recipe.materials == {}
+        assert recipe.output_type_id is None
+        assert recipe.output_quantity is None
+
+    def test_new_recipe_from_element(self):
+        """
+        Make a new recipe from an element
+        """
+        type_id = "Component"
+        amount = 1
+        sub_type_id = "some-subtype-id"
+        materials = {
+            "mat-1": 20,
+            "mat-2": 10
+        }
+
+        recipe_element = ElementTree.Element("Blueprint")
+        ElementTree.SubElement(recipe_element, "Result",
+                               attrib={"SubtypeId": sub_type_id,
+                                       "Amount": amount,
+                                       "TypeId": type_id})
+        prerequisites_element = ElementTree.SubElement(recipe_element, "Prerequisites")
+        for material, m_quantity in materials.items():
+            ElementTree.SubElement(prerequisites_element, "Item",
+                                   attrib={"SubtypeId": material,
+                                           "Amount": m_quantity})
+
+        recipe = Recipe()
+        recipe.from_element(recipe_element)
+
+        assert recipe.materials == materials
+        assert recipe.output_quantity == amount
+        assert recipe.output_type_id == sub_type_id
+
+    def test_new_recipe_from_element_no_result(self):
+        """
+        Make a new recipe from an element but there is no Result element
+        """
+        recipe_element = ElementTree.Element("Blueprint")
+
+        recipe = Recipe()
+        recipe.from_element(recipe_element)
+
+        assert recipe.materials == {}
+        assert recipe.output_quantity is None
+        assert recipe.output_type_id is None
+
+    def test_new_recipe_from_element_not_component(self):
+        """
+        Make a new recipe from an element that is not a component
+        """
+        type_id = "Ingot"
+        amount = 1
+        sub_type_id = "some-subtype-id"
+        materials = {
+            "mat-1": 20,
+            "mat-2": 10
+        }
+
+        recipe_element = ElementTree.Element("Blueprint")
+        ElementTree.SubElement(recipe_element, "Result",
+                               attrib={"SubtypeId": sub_type_id,
+                                       "Amount": amount,
+                                       "TypeId": type_id})
+
+        recipe = Recipe()
+        recipe.from_element(recipe_element)
+
+        assert recipe.materials == {}
+        assert recipe.output_quantity is None
+        assert recipe.output_type_id is None
+
+    def test_return_recipe_as_dict(self):
+        """
+        Return a recipe as a dictionary
+        """
+        amount = 1
+        sub_type_id = "some-subtype-id"
+        materials = {
+            "mat-1": 20,
+            "mat-2": 10
+        }
+
+        recipe = Recipe()
+        recipe.materials = materials
+        recipe.output_type_id = sub_type_id
+        recipe.output_quantity = amount
+
+        assert recipe.as_dict() == {
+            "materials": materials,
+            "output_type_id": sub_type_id,
+            "output_quantity": amount
         }


### PR DESCRIPTION
Adds a new section to the output for materials estimates.

```json
{
  "blocks": {
    "SmallBlockMediumContainer": 2
  },
  "components": {
    "InteriorPlate": 96,
    "Construction": 166
  },
  "unknown_blocks": [
    "AnotherBockType"
  ],
  "materials_estimate": {
    "Iron": 8522.0,
    "Silicon": 57.0,
    "Nickel": 490.0
  }
}
```